### PR TITLE
Updated dependencies such that newer downstream dependencies can use typepal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.rascalmpl</groupId>
                 <artifactId>rascal-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.14.5</version>
                 <configuration>
                     <bin>${project.build.outputDirectory}</bin>
                     <srcs>
@@ -69,6 +69,7 @@
                         <srcIgnore>${project.basedir}/src/examples</srcIgnore>
                     </srcIgnores>
                     <errorsAsWarnings>true</errorsAsWarnings>
+                    <enableStandardLibrary>false</enableStandardLibrary>
                 </configuration>
                 <executions>
                     <execution>
@@ -145,7 +146,7 @@
         <dependency>
         	<groupId>org.rascalmpl</groupId>
         	<artifactId>rascal</artifactId>
-        	<version>0.24.3</version>
+        	<version>0.28.3</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Related to [#usethesource/rascal-maven-plugin/13](https://github.com/usethesource/rascal-maven-plugin/issues/13).