### PR TITLE
wiring code actions from FailMessage to Message

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,7 +6,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="target/test-classes" path="src">
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
@@ -16,6 +16,23 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/src/analysis/typepal/FailMessage.rsc
+++ b/src/analysis/typepal/FailMessage.rsc
@@ -6,19 +6,20 @@ module analysis::typepal::FailMessage
 */
 import Message;
 import String;
+import util::IDEServices;
 
-data FailMessage
+data FailMessage(list[CodeAction] fixes = [])
     = fm_error(value src, str msg, list[value] args)
     | fm_warning(value src, str msg, list[value] args)
     | fm_info(value src, str msg, list[value] args)
     ;
     
-FailMessage error(value src, str msg, value args...) = fm_error(src, msg, args);
-FailMessage warning(value src, str msg, value args...) = fm_warning(src, msg, args);
-FailMessage info(value src, str msg, value args...) = fm_info(src, msg, args);
+FailMessage error(value src, str msg, value args..., list[CodeAction] fixes=[]) = fm_error(src, msg, args, fixes=fixes);
+FailMessage warning(value src, str msg, value args..., list[CodeAction] fixes=[]) = fm_warning(src, msg, args, fixes=fixes);
+FailMessage info(value src, str msg, value args..., list[CodeAction] fixes=[]) = fm_info(src, msg, args, fixes=fixes);
 
 str escapePercent(str s) = replaceAll(s, "%", "%%");
-
+ 
 FailMessage convert(error(str msg, loc at)) = fm_error(at, escapePercent(msg), []);
 FailMessage convert(warning(str msg, loc at)) = fm_warning(at, escapePercent(msg), []);
 FailMessage convert(info(str msg, loc at)) = fm_info(at, escapePercent(msg), []);

--- a/src/analysis/typepal/FailMessage.rsc
+++ b/src/analysis/typepal/FailMessage.rsc
@@ -20,6 +20,6 @@ FailMessage info(value src, str msg, value args..., list[CodeAction] fixes=[]) =
 
 str escapePercent(str s) = replaceAll(s, "%", "%%");
  
-FailMessage convert(error(str msg, loc at)) = fm_error(at, escapePercent(msg), []);
-FailMessage convert(warning(str msg, loc at)) = fm_warning(at, escapePercent(msg), []);
-FailMessage convert(info(str msg, loc at)) = fm_info(at, escapePercent(msg), []);
+FailMessage convert(error(str msg, loc at, fixes=list[CodeAction] fixes)) = fm_error(at, escapePercent(msg), [], fixes=fixes);
+FailMessage convert(warning(str msg, loc at, fixes=list[CodeAction] fixes)) = fm_warning(at, escapePercent(msg), [], fixes=fixes);
+FailMessage convert(info(str msg, loc at, fixes=list[CodeAction] fixes)) = fm_info(at, escapePercent(msg), [], fixes=fixes);

--- a/src/analysis/typepal/Messenger.rsc
+++ b/src/analysis/typepal/Messenger.rsc
@@ -10,6 +10,7 @@ import String;
 import Set;
 import List;
 import Location;
+import util::IDEServices;
 
 extend analysis::typepal::AType;
 extend analysis::typepal::Exception;
@@ -132,7 +133,7 @@ str interpolate(str msg, TypeProvider getType, list[value] args){
     return result;
 }
     
-Message fmt(str severity, value subject, str msg, TypeProvider getType, list[value] args){
+Message fmt(str severity, value subject, str msg, TypeProvider getType, list[value] args, list[CodeAction] fixes = []){
     fmsg = "";
     try {
         fmsg = interpolate(msg, getType, args);
@@ -145,19 +146,19 @@ Message fmt(str severity, value subject, str msg, TypeProvider getType, list[val
     else throw TypePalUsage("Subject in error should be have type `Tree` or `loc`, found <typeOf(subject)>");
 
     switch(severity){
-        case "error": return error(fmsg, sloc);
-        case "warning": return warning(fmsg, sloc);
-        case "info": return info(fmsg, sloc);
+        case "error": return error(fmsg, sloc, fixes=fixes);
+        case "warning": return warning(fmsg, sloc, fixes=fixes);
+        case "info": return info(fmsg, sloc, fixes=fixes);
         default: throw TypePalInternalError("Unknown severity <severity>");
     }
 }
     
-Message toMessage(fm_error(value src, str msg, list[value] args), TypeProvider getType) 
-    = fmt("error", src, msg, getType, args);
+Message toMessage(fm_error(value src, str msg, list[value] args, fixes=list[CodeAction] fixes), TypeProvider getType) 
+    = fmt("error", src, msg, getType, args, fixes=fixes);
 
-Message toMessage(fm_warning(value src, str msg, list[value] args), TypeProvider getType) 
-    = fmt("warning", src, msg, getType, args);
+Message toMessage(fm_warning(value src, str msg, list[value] args, fixes=list[CodeAction] fixes), TypeProvider getType) 
+    = fmt("warning", src, msg, getType, args, fixes=fixes);
     
-Message toMessage(fm_info(value src, str msg, list[value] args), TypeProvider getType) 
-    = fmt("info", src, msg, getType, args);
+Message toMessage(fm_info(value src, str msg, list[value] args, fixes=list[CodeAction] fixes), TypeProvider getType) 
+    = fmt("info", src, msg, getType, args, fixes=fixes);
     


### PR DESCRIPTION
Takes a `list[CodeAction] fixes=[]` keyword field and makes sure it ends up in a Message.