### PR TITLE
rewrote all declarations and uses of annotation syntax to keyword fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
                 <artifactId>rascal-maven-plugin</artifactId>
                 <version>0.30.7</version>
                 <configuration>
+                    <!-- BOOTSTRAP SETTING -->
+                    <errorsAsWarnings>true</errorsAsWarnings>
                     <bin>${project.build.outputDirectory}</bin>
                     <srcs>
                         <src>${project.basedir}/src</src>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>rascal</artifactId>
-            <version>0.42.0</version>
+            <version>0.43.0-BOOT1.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>typepal</artifactId>
-    <version>0.16.8-SNAPSHOT</version>
+    <version>0.17.0-BOOT1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/typepal.git</developerConnection>
-        <tag>v0.15.1</tag>
+        <tag>v0.17.0-BOOT1</tag>
   </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>typepal</artifactId>
-    <version>0.17.0-BOOT2</version>
+    <version>0.17.0-BOOT3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/typepal.git</developerConnection>
-        <tag>v0.17.0-BOOT2</tag>
+        <tag>v0.15.1</tag>
   </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>typepal</artifactId>
-    <version>0.17.0-BOOT1</version>
+    <version>0.17.0-BOOT2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/typepal.git</developerConnection>
-        <tag>v0.17.0-BOOT1</tag>
+        <tag>v0.15.1</tag>
   </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.rascalmpl</groupId>
     <artifactId>typepal</artifactId>
-    <version>0.17.0-BOOT2-SNAPSHOT</version>
+    <version>0.17.0-BOOT2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
 
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/usethesource/typepal.git</developerConnection>
-        <tag>v0.15.1</tag>
+        <tag>v0.17.0-BOOT2</tag>
   </scm>
 
     <build>

--- a/src/analysis/typepal/Collector.rsc
+++ b/src/analysis/typepal/Collector.rsc
@@ -299,7 +299,7 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
 
         nPredefinedTree += 1;
         return appl(prod(sort("$PREDEFINED-<id>"), [], {}),
-                    [])[src=defining[query="predefined=<id>"][fragment="<nPredefinedTree>"]];
+                    [])[@\loc=defining[query="predefined=<id>"][fragment="<nPredefinedTree>"]];
     }
 
     bool collector_isAlreadyDefined(str id,  Tree useOrDef){

--- a/src/analysis/typepal/Collector.rsc
+++ b/src/analysis/typepal/Collector.rsc
@@ -299,7 +299,7 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
 
         nPredefinedTree += 1;
         return appl(prod(sort("$PREDEFINED-<id>"), [], {}),
-                    [])[@\loc=defining[query="predefined=<id>"][fragment="<nPredefinedTree>"]];
+                    [])[src=defining[query="predefined=<id>"][fragment="<nPredefinedTree>"]];
     }
 
     bool collector_isAlreadyDefined(str id,  Tree useOrDef){

--- a/src/analysis/typepal/GetLoc.rsc
+++ b/src/analysis/typepal/GetLoc.rsc
@@ -21,12 +21,12 @@ import IO;
 
 loc getFirstLoc(Tree t) {
     for (a <- t.args) {
-        if (a@\loc?) {
-            return a@\loc;
+        if (a.src?) {
+            return a.src;
         }
     }
-    if(t@\loc?){
-        return t@\loc;
+    if(t.src?){
+        return t.src;
     }
     println("PANIC: getFirstLoc");
     println("Source text: <t>");
@@ -36,18 +36,18 @@ loc getFirstLoc(Tree t) {
 
 loc getLastLoc(Tree t) {
     for (i <- [size(t.args)-1..-1]) {
-        if (t.args[i]@\loc?) {
-            return  t.args[i]@\loc;
+        if (t.args[i].src?) {
+            return  t.args[i].src;
         }
     }
-    if(t@\loc?){
-        return t@\loc;
+    if(t.src?){
+        return t.src;
     }
     throw "Cannot find loc on tree";
 }
 
 loc getLoc(Tree t)
-    = t@\loc ? { fst = getFirstLoc(t); 
+    = t.src ? { fst = getFirstLoc(t); 
                  lst = getLastLoc(t);
                  n = fst[length=lst.offset - fst.offset + lst.length]; 
                  (n.end? && lst.end?) ? n[end=lst.end] : n;

--- a/src/analysis/typepal/GetLoc.rsc
+++ b/src/analysis/typepal/GetLoc.rsc
@@ -21,12 +21,12 @@ import IO;
 
 loc getFirstLoc(Tree t) {
     for (a <- t.args) {
-        if (a.src?) {
-            return a.src;
+        if (a@\loc?) {
+            return a@\loc;
         }
     }
-    if(t.src?){
-        return t.src;
+    if(t@\loc?){
+        return t@\loc;
     }
     println("PANIC: getFirstLoc");
     println("Source text: <t>");
@@ -36,15 +36,19 @@ loc getFirstLoc(Tree t) {
 
 loc getLastLoc(Tree t) {
     for (i <- [size(t.args)-1..-1]) {
-        if (t.args[i].src?) {
-            return  t.args[i].src;
+        if (t.args[i]@\loc?) {
+            return  t.args[i]@\loc;
         }
     }
-    if(t.src?){
-        return t.src;
+    if(t@\loc?){
+        return t@\loc;
     }
     throw "Cannot find loc on tree";
 }
 
 loc getLoc(Tree t)
-    = t.src;
+    = t@\loc ? { fst = getFirstLoc(t); 
+                 lst = getLastLoc(t);
+                 n = fst[length=lst.offset - fst.offset + lst.length]; 
+                 (n.end? && lst.end?) ? n[end=lst.end] : n;
+                 };

--- a/src/analysis/typepal/GetLoc.rsc
+++ b/src/analysis/typepal/GetLoc.rsc
@@ -21,12 +21,12 @@ import IO;
 
 loc getFirstLoc(Tree t) {
     for (a <- t.args) {
-        if (a@\loc?) {
-            return a@\loc;
+        if (a.src?) {
+            return a.src;
         }
     }
-    if(t@\loc?){
-        return t@\loc;
+    if(t.src?){
+        return t.src;
     }
     println("PANIC: getFirstLoc");
     println("Source text: <t>");
@@ -36,19 +36,15 @@ loc getFirstLoc(Tree t) {
 
 loc getLastLoc(Tree t) {
     for (i <- [size(t.args)-1..-1]) {
-        if (t.args[i]@\loc?) {
-            return  t.args[i]@\loc;
+        if (t.args[i].src?) {
+            return  t.args[i].src;
         }
     }
-    if(t@\loc?){
-        return t@\loc;
+    if(t.src?){
+        return t.src;
     }
     throw "Cannot find loc on tree";
 }
 
 loc getLoc(Tree t)
-    = t@\loc ? { fst = getFirstLoc(t); 
-                 lst = getLastLoc(t);
-                 n = fst[length=lst.offset - fst.offset + lst.length]; 
-                 (n.end? && lst.end?) ? n[end=lst.end] : n;
-                 };
+    = t.src;

--- a/src/analysis/typepal/TestFramework.rsc
+++ b/src/analysis/typepal/TestFramework.rsc
@@ -115,9 +115,9 @@ bool runTests(list[loc] suites, type[&T<:Tree] begin, TModel(Tree t) getModel, b
               if(!result) failedTests[<"<ti.name>", suite>] = messages; 
               //if(!result) iprintln(model);  
            } catch ParseError(loc l): {
-                failedTests[<"<ti.name>", suite>]  = [error("Parse error", relocate(l, ti.tokens.src))];
+                failedTests[<"<ti.name>", suite>]  = [error("Parse error", relocate(l, ti.tokens@\loc))];
            } catch Ambiguity(loc l, nt, inp): {
-                failedTests[<"<ti.name>", suite>]  = [error("Ambiguity (<nt> on `<inp>`)", (l.offset?) ? relocate(l, ti.tokens.src) : l)];
+                failedTests[<"<ti.name>", suite>]  = [error("Ambiguity (<nt> on `<inp>`)", (l.offset?) ? relocate(l, ti.tokens@\loc) : l)];
            } 
 
         }
@@ -159,7 +159,7 @@ lrel[&T<:Tree, set[str]] extractTests(list[loc] suites, type[&T<:Tree] begin) {
         
         for(TTL_TestItem ti <- ttlProgram.items){
             t = parse(begin, "<ti.tokens>");
-            result += <relocate(t, ti.tokens.src), ti.expect is none ? {} : {deescape("<s>"[1..-1]) | TTL_String s <- ti.expect.messages}>;
+            result += <relocate(t, ti.tokens@\loc), ti.expect is none ? {} : {deescape("<s>"[1..-1]) | TTL_String s <- ti.expect.messages}>;
         }
     }
     return result;
@@ -167,7 +167,7 @@ lrel[&T<:Tree, set[str]] extractTests(list[loc] suites, type[&T<:Tree] begin) {
 
 &T<:Tree relocate(&T<:Tree t, loc container) {
     return visit (t) {
-        case Tree tt => tt[src=relocate(tt.src, container)]
+        case Tree tt => tt[@\loc = relocate(tt@\loc, container)]
             when tt has \loc
     };
 }

--- a/src/analysis/typepal/TestFramework.rsc
+++ b/src/analysis/typepal/TestFramework.rsc
@@ -115,9 +115,9 @@ bool runTests(list[loc] suites, type[&T<:Tree] begin, TModel(Tree t) getModel, b
               if(!result) failedTests[<"<ti.name>", suite>] = messages; 
               //if(!result) iprintln(model);  
            } catch ParseError(loc l): {
-                failedTests[<"<ti.name>", suite>]  = [error("Parse error", relocate(l, ti.tokens@\loc))];
+                failedTests[<"<ti.name>", suite>]  = [error("Parse error", relocate(l, ti.tokens.src))];
            } catch Ambiguity(loc l, nt, inp): {
-                failedTests[<"<ti.name>", suite>]  = [error("Ambiguity (<nt> on `<inp>`)", (l.offset?) ? relocate(l, ti.tokens@\loc) : l)];
+                failedTests[<"<ti.name>", suite>]  = [error("Ambiguity (<nt> on `<inp>`)", (l.offset?) ? relocate(l, ti.tokens.src) : l)];
            } 
 
         }
@@ -159,7 +159,7 @@ lrel[&T<:Tree, set[str]] extractTests(list[loc] suites, type[&T<:Tree] begin) {
         
         for(TTL_TestItem ti <- ttlProgram.items){
             t = parse(begin, "<ti.tokens>");
-            result += <relocate(t, ti.tokens@\loc), ti.expect is none ? {} : {deescape("<s>"[1..-1]) | TTL_String s <- ti.expect.messages}>;
+            result += <relocate(t, ti.tokens.src), ti.expect is none ? {} : {deescape("<s>"[1..-1]) | TTL_String s <- ti.expect.messages}>;
         }
     }
     return result;
@@ -167,7 +167,7 @@ lrel[&T<:Tree, set[str]] extractTests(list[loc] suites, type[&T<:Tree] begin) {
 
 &T<:Tree relocate(&T<:Tree t, loc container) {
     return visit (t) {
-        case Tree tt => tt[@\loc = relocate(tt@\loc, container)]
+        case Tree tt => tt[src=relocate(tt.src, container)]
             when tt has \loc
     };
 }

--- a/src/analysis/typepal/refactor/Rename.rsc
+++ b/src/analysis/typepal/refactor/Rename.rsc
@@ -355,14 +355,14 @@ private map[Define, loc] defNameLocations(Tree tr, set[Define] defs, Renamer _r)
         def = definitions[d];
         top-down visit (tr) {
             case t:appl(_, _):
-                if (t.src?, d := t.src) {
+                if (t@\loc?, d := t@\loc) {
                     return (def: nameLocation(t, def));
                 }
         }
     }
 
     map[Define, loc] defNames = ();
-    for (defsToDo != {}, /t:appl(_, _) := tr, t.src?, loc d := t.src, d in defsToDo) {
+    for (defsToDo != {}, /t:appl(_, _) := tr, t@\loc?, loc d := t@\loc, d in defsToDo) {
         def = definitions[d];
         defNames[def] = nameLocation(t, def);
         defsToDo -= d;
@@ -430,8 +430,8 @@ default void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
 @synopsis{Finds the location of the identifier within definition ((ParseTree::Tree)) `t` corresponding to ((Define)) `d`, where `t.src == d.defined`.}
 default loc nameLocation(Tree t, Define d) {
     // Try to find the first sub-tree that matches the name of the definition
-    for (/Tree tr := t, tr.src?, "<tr>" == d.id) {
-        return tr.src;
+    for (/Tree tr := t, tr@\loc?, "<tr>" == d.id) {
+        return tr@\loc;
     }
-    return t.src;
+    return t@\loc;
 }

--- a/src/analysis/typepal/refactor/Rename.rsc
+++ b/src/analysis/typepal/refactor/Rename.rsc
@@ -355,14 +355,14 @@ private map[Define, loc] defNameLocations(Tree tr, set[Define] defs, Renamer _r)
         def = definitions[d];
         top-down visit (tr) {
             case t:appl(_, _):
-                if (t@\loc?, d := t@\loc) {
+                if (t.src?, d := t.src) {
                     return (def: nameLocation(t, def));
                 }
         }
     }
 
     map[Define, loc] defNames = ();
-    for (defsToDo != {}, /t:appl(_, _) := tr, t@\loc?, loc d := t@\loc, d in defsToDo) {
+    for (defsToDo != {}, /t:appl(_, _) := tr, t.src?, loc d := t.src, d in defsToDo) {
         def = definitions[d];
         defNames[def] = nameLocation(t, def);
         defsToDo -= d;
@@ -430,8 +430,8 @@ default void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
 @synopsis{Finds the location of the identifier within definition ((ParseTree::Tree)) `t` corresponding to ((Define)) `d`, where `t.src == d.defined`.}
 default loc nameLocation(Tree t, Define d) {
     // Try to find the first sub-tree that matches the name of the definition
-    for (/Tree tr := t, tr@\loc?, "<tr>" == d.id) {
-        return tr@\loc;
+    for (/Tree tr := t, tr.src?, "<tr>" == d.id) {
+        return tr.src;
     }
-    return t@\loc;
+    return t.src;
 }

--- a/src/examples/modfun/Checker.rsc
+++ b/src/examples/modfun/Checker.rsc
@@ -61,7 +61,7 @@ TModel modfunTModelFromTree(Tree pt, TypePalConfig config) {
     if (pt has top) pt = pt.top;
     c = newCollector("modfun", pt, config);
     collect(pt, c);
-    handleImports(c, pt, pathConfig(pt@\loc));
+    handleImports(c, pt, pathConfig(pt.src));
     return newSolver(pt, c.run()).run();
 }
 

--- a/src/examples/modfun/Checker.rsc
+++ b/src/examples/modfun/Checker.rsc
@@ -61,7 +61,7 @@ TModel modfunTModelFromTree(Tree pt, TypePalConfig config) {
     if (pt has top) pt = pt.top;
     c = newCollector("modfun", pt, config);
     collect(pt, c);
-    handleImports(c, pt, pathConfig(pt.src));
+    handleImports(c, pt, pathConfig(pt@\loc));
     return newSolver(pt, c.run()).run();
 }
 

--- a/src/examples/modules/Checker.rsc
+++ b/src/examples/modules/Checker.rsc
@@ -122,7 +122,7 @@ TModel modulesTModelFromTree(Tree pt){
     if (pt has top) pt = pt.top;
     c = newCollector("modules", pt, getModulesConfig());
     collect(pt, c);
-    handleImports(c, pt, pathConfig(pt.src));
+    handleImports(c, pt, pathConfig(pt@\loc));
     return newSolver(pt, c.run()).run();
 }
 

--- a/src/examples/modules/Checker.rsc
+++ b/src/examples/modules/Checker.rsc
@@ -122,7 +122,7 @@ TModel modulesTModelFromTree(Tree pt){
     if (pt has top) pt = pt.top;
     c = newCollector("modules", pt, getModulesConfig());
     collect(pt, c);
-    handleImports(c, pt, pathConfig(pt@\loc));
+    handleImports(c, pt, pathConfig(pt.src));
     return newSolver(pt, c.run()).run();
 }
 

--- a/src/examples/pascal/Checker.rsc
+++ b/src/examples/pascal/Checker.rsc
@@ -145,11 +145,10 @@ bool pascalIsSubType(AType atype, functionType(_, atype)) = true;  // for assign
 
 default bool pascalIsSubType(AType atype1, AType atype2) = false;
 
- 
-data Tree(loc src = |unknown:///|);
+anno loc Tree@src;
 
 void pascalPreCollectInitialization(Tree t, Collector c){
-    container = t.src;
+    container = t@src;
     
     c.predefine("true",    constantId(),   container, defType(booleanType()));
     c.predefine("false",   constantId(),   container, defType(booleanType()));

--- a/src/examples/pascal/Checker.rsc
+++ b/src/examples/pascal/Checker.rsc
@@ -145,10 +145,11 @@ bool pascalIsSubType(AType atype, functionType(_, atype)) = true;  // for assign
 
 default bool pascalIsSubType(AType atype1, AType atype2) = false;
 
-anno loc Tree@src;
+ 
+data Tree(loc src = |unknown:///|);
 
 void pascalPreCollectInitialization(Tree t, Collector c){
-    container = t@src;
+    container = t.src;
     
     c.predefine("true",    constantId(),   container, defType(booleanType()));
     c.predefine("false",   constantId(),   container, defType(booleanType()));


### PR DESCRIPTION
This is part of solving https://github.com/usethesource/rascal/issues/2745

* [ ] To continue with this we first need a standard library without annotation declarations or uses
* [ ] Then a release of typepal based on that stdlib and this PR.