### PR TITLE
Sketch of a dependency debugger

### DIFF
--- a/src/analysis/typepal/Collector.rsc
+++ b/src/analysis/typepal/Collector.rsc
@@ -208,6 +208,9 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
 
     map[loc,loc] physical2logical = ();
 
+    bool debugDependencies = true;
+    rel[loc, loc] debugDependencyGraph = {};
+
     loc getLogicalLoc(loc l)
         = l in physical2logical ? physical2logical[l] : l;
 
@@ -647,6 +650,9 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
         if(building){
            srcLoc = getLoc(src);
            calculators += calc(name, srcLoc, dependenciesAslocList(dependencies) - srcLoc, calculator);
+           if (debugDependencies) {
+              debugDependencyGraph += {src} * {d | d <- dependencies, d@\loc?, d@\loc};
+           }
         } else {
             throw TypePalUsage("Cannot call `calculate` on Collector after `run`");
         }
@@ -656,6 +662,9 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
         if(building){
            srcLoc = getLoc(src);
            calculators += calc(name, srcLoc, dependenciesAslocList(dependencies) - srcLoc, calculator, eager=true);
+           if (debugDependencies) {
+              debugDependencyGraph += {src} * {d | d <- dependencies, d@\loc?, d@\loc};
+           }
         } else {
             throw TypePalUsage("Cannot call `calculateEager` on Collector after `run`");
         }
@@ -1022,7 +1031,9 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
            tm.store = toLogicalLocs(storeVals); storeVals = ();
            tm.messages = toList(toSet(toPhysicalLocs(messages) + addedMessages)); messages = addedMessages = [];
            physical2logical = logical2physical = ();
-
+           if (debugDependencies) {
+              tm.debugDependencyGraph = debugDependencyGraph;
+           }
            return tm;
         } else {
            throw TypePalUsage("Cannot call `run` on Collector after `run`");

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -123,6 +123,8 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
 
     Paths solver_getPaths() = tm.paths;
 
+    rel[loc,loc] debugDependencyGraph = tm.debugDependencyGraph+; // notice the transitive closure
+
     map[PathRole,rel[loc,loc]] solver_getPathsByPathRole() = pathsByPathRole;
 
      loc getLogicalLoc(Tree t){
@@ -415,6 +417,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
     bool evalCalc(calc:calc(str cname, loc src, list[loc] dependsOn,  AType(Solver tm) getAType)){
         if(allDependenciesKnown(dependsOn, calc.eager)){
             try {
+                currentSolve = src;
                 facts[src] = instantiate(getAType(thisSolver));
                 bindings2facts(bindings);
                 fireTrigger(src);
@@ -560,7 +563,13 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
     AType solver_getType(value v){
         try {
             switch(v){
-                case Tree tree:   return instantiate(findType(getLogicalLoc(tree)));
+                case Tree tree: {
+                    if (debugDependencies, tree@\loc notin debugDependencyGraph[currentSolve]) {
+                        throw "WARNING there is no explicit (transitive) dependency on position <v> via the currently solved position <currentSolve>";
+                    }
+
+                    return instantiate(findType(getLogicalLoc(tree)));
+                }
                 case tvar(loc l): return facts[getLogicalLoc(l)];
                 case AType atype: return instantiate(atype);
                 case loc l: {

--- a/src/analysis/typepal/TModel.rsc
+++ b/src/analysis/typepal/TModel.rsc
@@ -114,6 +114,7 @@ data TModel (
     map[str,value] store = (),
     map[loc, Define] definitions = (),
     map[loc,loc] logical2physical = (),
+    rel[loc,loc] debugDependencyGraph = {},
     bool usesPhysicalLocs = false, // Are locations in physical format?
     TypePalConfig config = tconfig()
 )   = tmodel();


### PR DESCRIPTION
This is not working code. Just a sketch to see how a missing dependency debugger would work:
* [ ] collect calculator dependencies in a relation loc x loc during collect (not complete)
* [x] store dependency graph in TModel
* [ ] rename physical locations to logical locations in dependency graph (not started)
* [ ] close dependency graph in Collector and use negative lookups  with getType (not complete)

@PaulKlint Is this early transitive closure ever going to be complete if more logical names can be discovered later during solving?