### PR TITLE
Fix `collector_useViaType`

### DIFF
--- a/src/analysis/typepal/Collector.rsc
+++ b/src/analysis/typepal/Collector.rsc
@@ -384,6 +384,7 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
 
     void collector_useViaType(Tree container, Tree selector, set[IdRole] idRolesSel){
         if(building){
+            collector_use(selector, idRolesSel);
             name = normalizeName("<selector>");
             selectorLoc = getLoc(selector);
             containerLoc = getLoc(container);

--- a/src/examples/fwjava/Test.rsc
+++ b/src/examples/fwjava/Test.rsc
@@ -41,4 +41,28 @@ test bool fwjTests() {
                      runName = "FwJava");
 }
 
+test bool fwjUseDefTests1() = checkUseDefsOf("cpt");
+test bool fwjUseDefTests2() = checkUseDefsOf("pair");
+test bool fwjUseDefTests3() = checkUseDefsOf("tmp");
+
+private bool checkUseDefsOf(str name) {
+    tm = fwjTModelFromName(name, false);
+    assert size(tm.useDef) > 0 : "Expected: \>0 use-defs. Actual: <size(tm.useDef)>.";
+
+    for (<lUse, lDef> <- tm.useDef) {
+        uses = [u | u: use(_, _, lUse, _, _) <- tm.uses];
+        assert [] != uses : "Expected: Use at <lUse>. Actual: No use.";
+
+        defs = [d | d: <_, _, _, _, lDef, _> <- tm.defines];
+        assert [] != defs : "Expected: Def at <lDef>. Actual: No def."; 
+
+        for (u <- uses, d <- defs) {
+            assert u.id == d.id : "Expected: Equal `id`. Actual: `<u.id>` (use) vs. `<d.id>` (def)";
+            assert u.orgId == d.orgId : "Expected: Equal `orgId`. Actual: `<u.id>` (use) vs. `<d.id>` (def)";
+        }
+    }
+
+    return true;
+}
+
 value main() = fwjTests();


### PR DESCRIPTION
This PR fixes the issue that `collector_useViaType` scheduled a callback to calculate the type of a tree (the "selector") based on the type of another tree (the "container"), but it didn't collect  the selector as a `Use` in `uses` yet.

This PR also adds a first test (to the FWJ example) to check the consistency of the `useDef`, `uses`, and `defines` data in a TModel. Without the fix of this PR, this test fails.