### PR TITLE
Stop copying messages from added TModels

### DIFF
--- a/src/analysis/typepal/Collector.rsc
+++ b/src/analysis/typepal/Collector.rsc
@@ -936,7 +936,7 @@ Collector newCollector(str modelName, map[str,Tree] namedTrees, TypePalConfig co
         }
 
         logical2physical += tm.logical2physical;
-        addedMessages += tm.messages;
+        //addedMessages += tm.messages;
 
         addedScopes += tm.scopes;
         scopes += tm.scopes;


### PR DESCRIPTION
Currently addTModel adds all messages from the added TModel to the current TModel and this leads to an avalanche of messages. This is addressed here.