### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - performance-improvements-main
 
 env:
   MAVEN_OPTS: "-Xmx6G -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - main
-      - performance-improvements-main
 
 env:
   MAVEN_OPTS: "-Xmx6G -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -426,21 +426,15 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
     private set[loc] lookupPathsWide(loc scope, Use use, PathRole pathRole){
         // dbgEnter("lookupPathsWide: <use.id> in scope <scope>, role <pathRole>");;
         res = {};
-
-        seenParents = {};
-        solve(res, scope) {
-        next_path:
-            for(<scope, loc parent> <- pathsByPathRole[pathRole] ? {}, parent notin seenParents){
-                seenParents += parent;
-                for(loc def <- lookupScopeWide(parent, use)){
-                    switch(isAcceptablePathFun(parent, def, use, pathRole, the_solver)){
-                    case acceptBinding():
-                       res += def;
-                     case ignoreContinue():
-                          continue;
-                     case ignoreSkipPath():
-                          continue next_path;
-                    }
+        for (<scope, loc parent> <- pathsByPathRole[pathRole] ? {}) {
+            for (loc def <- lookupScopeWide(parent, use)) {
+                switch (isAcceptablePathFun(parent, def, use, pathRole, the_solver)) {
+                case acceptBinding():
+                    res += def;
+                case ignoreContinue():
+                    continue; // Continue inner loop
+                case ignoreSkipPath():
+                    break; // Break inner loop (continue outer loop)
                 }
             }
         }

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -75,6 +75,11 @@ bool defaultReportUnused (loc _, TModel _) {
     return false;
 }
 
+list[loc] defaultFilterUnused(list[loc] defs, TModel tm) {
+    bool(loc, TModel) reportUnused = tm.config.reportUnused;
+    return [d | loc d <- defs, reportUnused(d, tm)];
+}
+
 // https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#:~:text=A%20URI%20is%20composed%20from,)%2C%20and%20the%20character%20%25%20.
 // gen-delims: : / ? # [ ] @
 // sub-delims: ! $ & ' ( ) * + , ;
@@ -156,6 +161,8 @@ data TypePalConfig(
         void (map[str,Tree] namedTrees, Solver s) postSolver  = void(map[str,Tree] _, Solver _) { return ; },
 
         bool(loc def, TModel tm) reportUnused = defaultReportUnused,
+
+        list[loc](list[loc] defs, TModel tm) filterUnused = defaultFilterUnused,
 
         loc (Define def, str modelName, PathConfig pcfg) createLogicalLoc = defaultLogicalLoc,
 

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -497,13 +497,24 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
         return res;
     }
 
-    public set[loc] lookupWide(Use u){
+    // Cache to store results of `lookupWide`. The assumption is that syntactic
+    // scopes will not change between calls, but semantic paths might, so the
+    // cache needs to be invalidated when `the_solver.getPathsByPathRole()`
+    // returns an updated value (relative to the previous call of `lookupWide`).
+    map[Use, set[loc]] lookupWideCache = ();
 
+    public set[loc] lookupWide(Use u){
         // Update current paths and pathRoles
         current_pathsByPathRole =  the_solver.getPathsByPathRole();
         if(current_pathsByPathRole != pathsByPathRole){
             pathsByPathRole = current_pathsByPathRole;
             pathRoles = domain(pathsByPathRole);
+            lookupWideCache = ();
+        }
+
+        if (u in lookupWideCache) {
+            set[loc] defs = lookupWideCache[u];
+            if (isEmpty(defs)) throw NoBinding(); else return defs;
         }
 
         scope = u.scope;
@@ -512,6 +523,7 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
         // dbgPaths();
         if(!(u has qualifierRoles)){
            defs = {def | loc def <- lookupNestWide(scope, u), isAcceptableSimpleFun(def, u, the_solver) == acceptBinding()};
+           lookupWideCache[u] = defs;
         //    dbg("lookupWide: <u> =\> <defs>");
            if(isEmpty(defs)) throw NoBinding(); else return defs;
         } else {
@@ -528,6 +540,7 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
                     scopeLookups = lookupNestWide(qscope, use(u.ids[-1], "<u.occ>", u.occ, qscope, u.idRoles));
                     defs += { def | def <- scopeLookups, isAcceptableQualifiedFun(def, u, the_solver) == acceptBinding()};
                 }
+                lookupWideCache[u] = defs;
                 if(!isEmpty(defs)){
                     // dbg("lookupWide: <u> returns:\n<for(d <- defs){>\t==\> <d><}>");
                     return defs;

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -421,12 +421,29 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
         return res;
     }
 
+    // Cache to store results of `getPathTargets`. The assumption is that
+    // semantic paths might change between calls, so the cache needs to be
+    // invalidated when `the_solver.getPathsByPathRole()` returns an updated
+    // value (relative to the previous call of `getPathTargets`).
+    map[PathRole, map[loc, set[loc]]] getPathTargetsCache = ();
+
+    // Gets the target of each path with the provided role and source
+    set[loc] getPathTargets(PathRole role, loc source) {
+        if (role notin getPathTargetsCache) {
+            getPathTargetsCache[role] = ();
+        }
+        if (source notin getPathTargetsCache[role]) {
+            getPathTargetsCache[role][source] = {target | <source, loc target> <- pathsByPathRole[role]};
+        }
+        return getPathTargetsCache[role][source];
+    }
+
     //@memo
     // Find all (semantics induced, one-level) bindings for use in given syntactic scope via PathRole
     private set[loc] lookupPathsWide(loc scope, Use use, PathRole pathRole){
         // dbgEnter("lookupPathsWide: <use.id> in scope <scope>, role <pathRole>");;
         res = {};
-        for (<scope, loc parent> <- pathsByPathRole[pathRole] ? {}) {
+        for (loc parent <- getPathTargets(pathRole, scope)) {
             for (loc def <- lookupScopeWide(parent, use)) {
                 switch (isAcceptablePathFun(parent, def, use, pathRole, the_solver)) {
                 case acceptBinding():
@@ -498,6 +515,7 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
         if(current_pathsByPathRole != pathsByPathRole){
             pathsByPathRole = current_pathsByPathRole;
             pathRoles = domain(pathsByPathRole);
+            getPathTargetsCache = ();
         }
 
         scope = u.scope;

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -163,7 +163,7 @@ data TypePalConfig(
 
         bool enableErrorFixes = true,
 
-        bool enableSortedMessages = true,
+        bool enableSortedMessages = false,
 
         int cutoffForNameSimilarity = 3
     );

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -404,11 +404,30 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
     /* parents) and definitions that can be reached in a single step via semantic links */
     /************************************************************************************/
  
+    // Convert `tm.definesMap` to a more efficient representation for the kind
+    // of lookups that are performed in `bindWide`. The idea is to convert only
+    // once, and enjoy a return on investment each time when a lookup is
+    // performed in it (instead of also needing a `domainR` call each time).
+    map[loc, map[str, map[IdRole, set[loc]]]] convertDefinesMap() {
+        // Conversion function for the outer map
+        map[loc, map[str, map[IdRole, set[loc]]]] convert(map[loc, map[str, rel[IdRole, loc]]] scope2id2pairs) {
+            return (scope: convert(scope2id2pairs[scope]) | loc scope <- scope2id2pairs);
+        }
+        // Conversion function for the inner maps
+        map[str, map[IdRole, set[loc]]] convert(map[str, rel[IdRole, loc]] id2pairs) {
+            return (id: Relation::index(id2pairs[id]) | str id <- id2pairs);
+        }
+        return convert(tm.definesMap);
+    }
+
+    // Convert only once
+    map[loc, map[str, map[IdRole, set[loc]]]] scope2id2role2defs = convertDefinesMap();
+
     //@memo
     // Retrieve all bindings for use in given syntactic scope
     private set[loc] bindWide(loc scope, str id, set[IdRole] idRoles){
-        idsInScope = (scope in tm.definesMap) ? tm.definesMap[scope] : ();
-        foundDefs = id in idsInScope ? domainR(idsInScope[id], idRoles)<1> : {};
+        map[IdRole, set[loc]] role2defs = (scope2id2role2defs[scope] ? ())[id] ? ();
+        foundDefs = {*(role2defs[role] ? {}) | IdRole role <- idRoles};
         // dbg("bindWide: <scope>, <id> =\> <foundDefs>");
         return foundDefs;
     }

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -163,6 +163,8 @@ data TypePalConfig(
 
         bool enableErrorFixes = true,
 
+        bool enableSortedMessages = true,
+
         int cutoffForNameSimilarity = 3
     );
 

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -410,14 +410,14 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
     // performed in it (instead of also needing a `domainR` call each time).
     map[loc, map[str, map[IdRole, set[loc]]]] convertDefinesMap() {
         // Conversion function for the outer map
-        map[loc, map[str, map[IdRole, set[loc]]]] convert(map[loc, map[str, rel[IdRole, loc]]] scope2id2pairs) {
-            return (scope: convert(scope2id2pairs[scope]) | loc scope <- scope2id2pairs);
+        map[loc, map[str, map[IdRole, set[loc]]]] convertOuter(map[loc, map[str, rel[IdRole, loc]]] scope2id2pairs) {
+            return (scope: convertInner(scope2id2pairs[scope]) | loc scope <- scope2id2pairs);
         }
         // Conversion function for the inner maps
-        map[str, map[IdRole, set[loc]]] convert(map[str, rel[IdRole, loc]] id2pairs) {
+        map[str, map[IdRole, set[loc]]] convertInner(map[str, rel[IdRole, loc]] id2pairs) {
             return (id: Relation::index(id2pairs[id]) | str id <- id2pairs);
         }
-        return convert(tm.definesMap);
+        return convertOuter(tm.definesMap);
     }
 
     // Convert only once. (Note: this variable is local to `newScopeGraph`, so

--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -420,7 +420,8 @@ ScopeGraph newScopeGraph(TModel tm, TypePalConfig config){
         return convert(tm.definesMap);
     }
 
-    // Convert only once
+    // Convert only once. (Note: this variable is local to `newScopeGraph`, so
+    // always associated with the same TModel.)
     map[loc, map[str, map[IdRole, set[loc]]]] scope2id2role2defs = convertDefinesMap();
 
     //@memo

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -1830,7 +1830,11 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
             }
         }
         messages =  visit(messages) { case loc l => solver_toPhysicalLoc(l) };
-        tm.messages = sortMostPrecise(toList(toSet(messages)));
+        messages = toList(toSet(messages)); // Remove duplicates
+        if (tm.config.enableSortedMessages) {
+            messages = sortMostPrecise(messages);
+        }
+        tm.messages = messages;
 
         assertValidDefines(tm);
         assertValidUseDef(tm, thisSolver);

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -1645,14 +1645,29 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
 
         /****************** end of main solve loop *****************************/
 
+        // Creating new `defType` values using the `defType` constructor takes
+        // significant interpreter time. To make it faster, the following map
+        // stores "prototypes" from which new `defType` values can be created.
+        map[AType, DefInfo] defInfoPrototypes = ();
+
+        DefInfo newDefInfo(AType t, map[str, value] keywordParameters) {
+            DefInfo proto;
+            if (t in defInfoPrototypes) {
+                proto = defInfoPrototypes[t];
+            } else {
+                proto = defType(t);
+                defInfoPrototypes[t] = proto;
+            }
+            return setKeywordParameters(proto, keywordParameters); // Create new value (i.e., leave `proto` unchanged)
+        }
+
         // Eliminate all defTypeCalls before handing control to the postSolver
         for(loc l <- definitions){
             Define def = definitions[l];
             if(defTypeCall(_, AType(Solver s) getAType) := def.defInfo){
                 kwparams = getKeywordParameters(def.defInfo);
                 try {
-                    di = defType(getAType(thisSolver));
-                    def.defInfo = setKeywordParameters(di, kwparams);
+                    def.defInfo = newDefInfo(getAType(thisSolver), kwparams);
                     definitions[l] = def;
                 } catch _: { // Guard against type incorrect defines, but record for now
                     ; //println("Skipping (type-incorrect) def: <def>\n");
@@ -1663,11 +1678,16 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
 
         newDefines =
             for(def <- defines){
+                // All `defTypeCall` values have already been eliminated from
+                // `definitions`, so this is a fast(er) way out.
+                if (def.defined in definitions) {
+                    append definitions[def.defined];
+                    continue;
+                }
                 if(defTypeCall(_, AType(Solver s) getAType) := def.defInfo){
                     kwparams = getKeywordParameters(def.defInfo);
                     try {
-                        di = defType(getAType(thisSolver));
-                        def.defInfo = setKeywordParameters(di, kwparams);
+                        def.defInfo = newDefInfo(getAType(thisSolver), kwparams);
                     } catch _: { // Guard against type incorrect defines, but record for now
                         ; //println("Skipping (type-incorrect) def: <def>\n");
                     }
@@ -1805,16 +1825,14 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
         ldefines = for(tup: <loc _, str _, str _, IdRole _, loc defined, DefInfo defInfo> <- tm.defines){
                         if(defInfo has tree){
                             l = getLogicalLoc(defInfo.tree);
-                            if(l in tm.facts){
-                                   dt = defType(tm.facts[l]);
-                                   tup.defInfo = setKeywordParameters(dt, getKeywordParameters(defInfo));
+                            if(l in facts){
+                                tup.defInfo = newDefInfo(facts[l], getKeywordParameters(defInfo));
                             } else {
                                 continue;
                             }
                         } else {
-                            if(defined in tm.facts){
-                                dt = defType(tm.facts[defined]);
-                                tup.defInfo = setKeywordParameters(dt, getKeywordParameters(defInfo));
+                            if(defined in facts){
+                                tup.defInfo = newDefInfo(facts[defined], getKeywordParameters(defInfo));
                             } else {
                                 continue;
                             }

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -1038,6 +1038,41 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
         return newPathFound;
     }
 
+    // ---- Illegal overloading -----------------------------------------------
+
+    void checkIllegalOverloadingOfUnusedDefinitions() {
+        map[str, set[Define]] definesById = Relation::index({<d.id, d> | Define d <- defines});
+        for (str id <- definesById) {
+            set[Define] definesOfId = definesById[id];
+
+            // `id` can be illegally overloaded only if it isn't unique (i.e.,
+            // it has at least two definitions).
+            for (size(definesOfId) >= 2, Define d <- definesOfId, !isUsed(d)) {
+
+                // Turn unused definition into use and check for double
+                // declarations using scope graph lookup (i.e., not each
+                // definition in `definesOfId` might be in scope of `d`).
+                Use u = use(d.id, d.orgId, d.defined, d.scope, {d.idRole});
+                try {
+                    set[loc] foundDefs = scopeGraph.lookup(u);
+                    if (size(foundDefs) > 1 && !mayOverloadFun(foundDefs, definitions)) {
+                        doubleDefs += foundDefs;
+                        messages += [error("Double declaration of `<u.orgId>`", d1, 
+                                        causes=[info("Other declaration of `<u.orgId>`", d2) | d2 <- foundDefs, d2 != d1 ]) 
+                                    | d1 <- foundDefs, isContainedIn(u.scope, definitions[d1].scope, logical2physical)
+                                    ];
+                    }
+                }
+                catch NoBinding(): {;}
+                catch TypeUnavailable(): {;}
+            }
+        }
+    }
+
+    bool isUsed(Define d) {
+        return d.defined in def2uses;
+    }
+
     // ---- "equal" and "requireEqual" ----------------------------------------
 
     bool solver_equal(value given, value expected){
@@ -1467,41 +1502,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
             }
         }
 
-        // Check for illegal overloading of unused definitions
-        set[loc] unusedDefs = domain(definitions) - actuallyUsedDefs;
-
-        for(ud <- unusedDefs){
-            udef = definitions[ud];
-
-            scope = udef.scope;
-            id = udef.id;
-            orgId = udef.orgId;
-            idRole = udef.idRole;
-            defined = udef.defined;
-            //if(defined in logical2physical) defined = logical2physical[defined];
-
-            u = use(id, orgId, defined, scope, {idRole}); // turn each unused definition into a use and check for double declarations;
-            try {
-               foundDefs = scopeGraph.lookup(u);
-                if(isEmpty(foundDefs)){
-                    ;//throw TypePalInternalError("No binding found while checking for double definitions");
-               } else
-               if(size(foundDefs) == 1 || mayOverloadFun(foundDefs, definitions)){
-                 ;
-                } else {
-                    doubleDefs += foundDefs;
-                    messages += [error("Double declaration of `<u.orgId>`", d1, 
-                                       causes=[info("Other declaration of `<u.orgId>`", d2) | d2 <- foundDefs, d2 != d1 ]) 
-                                | d1 <- foundDefs, isContainedIn(u.scope, definitions[d1].scope, logical2physical)
-                                ];
-                }
-            }
-            catch NoBinding(): {
-                ;//throw TypePalInternalError("No binding found while checking for double definitions");
-            }
-        }
-
-        unusedDefs = actuallyUsedDefs = {};
+        checkIllegalOverloadingOfUnusedDefinitions();
 
         // Process all defines (which may create new calculators/facts)
 

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -1024,18 +1024,47 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
         }
         newPaths = { tup | tup:<loc u, PathRole _, loc d> <- newPaths, u != d };
         tm.referPaths = referPaths;
-        newPathFound = !isEmpty(newPaths);
-        if(   newPathFound                                      // we found new paths
-           || (!isEmpty(tm.paths) && isEmpty(pathsByPathRole))  // pathsByPathRole not yet initialized
-           ){
-            tm.paths += newPaths;
-            pathsByPathRole = ();
-            for(<loc u, PathRole r, loc d> <- tm.paths){
-                pathsByPathRole[r] ? {} += {<u, d>};
-            }
+        tm.paths += newPaths;
+
+        initPathsByPathRole();
+        updatePathsByPathRole(newPaths);
+        return !isEmpty(newPaths);
+    }
+
+    void initPathsByPathRole() {
+        if (!isEmpty(pathsByPathRole)) { // Already initialized
+            return;
         }
         
-        return newPathFound;
+        paths = tm.paths;
+        if (isEmpty(paths)) { // Nothing to initialize
+            return;
+        }
+
+        pathsByPathRole = (r: {} | <_, PathRole r, _> <- paths);
+        for (PathRole r <- pathsByPathRole) {
+            pathsByPathRole[r] = {<u, d> | <loc u, r, loc d> <- paths};
+        }
+        // That is, first compute the keys, and second compute the total
+        // values. It seems to be significantly faster than computing keys
+        // and total values together:
+        // ```
+        // pathsByPathRole = (r: {<u, d> | <loc u, r, loc d> <- paths} | <_, PathRole r, _> <- paths);
+        // ```
+        // It also seems to be significantly faster than computing keys
+        // and partial values iteratively:
+        // ```
+        // pathsByPathRole = ();
+        // for (<loc u, PathRole r, loc d> <- tm.paths) {
+        //     pathsByPathRole[r] ? {} += {<u, d>};
+        // }
+        // ```
+    }
+
+    void updatePathsByPathRole(Paths newPaths) {
+        for(<loc u, PathRole r, loc d> <- newPaths){
+            pathsByPathRole[r] ? {} += {<u, d>};
+        }
     }
 
     // ---- "equal" and "requireEqual" ----------------------------------------

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -141,7 +141,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
 
     AType(AType containerType, Tree selector, loc scope, Solver s) getTypeInNamelessTypeFun = defaultGetTypeInNamelessType;
 
-    bool(loc def, TModel tm) reportUnused = defaultReportUnused;
+    list[loc](list[loc] defs, TModel tm) filterUnused = defaultFilterUnused;
 
     map[loc,loc] logical2physical = tm.logical2physical;
 
@@ -177,7 +177,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
         getTypeNamesAndRole = tc.getTypeNamesAndRole;
         getTypeInTypeFromDefineFun = tc.getTypeInTypeFromDefine;
         getTypeInNamelessTypeFun = tc.getTypeInNamelessType;
-        reportUnused = tc.reportUnused;
+        filterUnused = tc.filterUnused;
     }
 
     TypePalConfig solver_getConfig() = tm.config;
@@ -1823,12 +1823,9 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
                       };
         tm.defines = toSet(ldefines);
 
-        for(Define def <- tm.defines){
-            defdefined = solver_toPhysicalLoc(def.defined);
-            if(defdefined notin def2uses && defdefined notin doubleDefs && reportUnused(defdefined, tm)){
-                messages += warning("Unused <prettyRole(def.idRole)> `<def.id>`", defdefined);
-            }
-        }
+        list[loc] unused = filterUnused([l | Define def <- tm.defines, loc l := solver_toPhysicalLoc(def.defined), l notin def2uses, l notin doubleDefs], tm);
+        messages += [warning("Unused <prettyRole(def.idRole)> `<def.id>`", l) | loc l <- unused, Define def := definitions[l]];
+        
         messages =  visit(messages) { case loc l => solver_toPhysicalLoc(l) };
         tm.messages = sortMostPrecise(toList(toSet(messages)));
 


### PR DESCRIPTION
This PR introduces various performance improvements. Each improvement is contributed in a separate sub-PR.

Sub-PRs:

  - Improvements to `ConfigurableScopeGraph`:
      - #55
      - #56
      - #57
  - Improvements to `Solver`:
      - #58
      - #59
      - #62
      - #60
      - #63

Integration test succeeds:
  - With current Rascal `main`: https://github.com/usethesource/rascal-core-big-tests/actions/runs/31808803232 -- **roughly 1.5x faster**
  - With a branch that introduces additional performance improvements (to be merged into Rascal `main` later): https://github.com/usethesource/rascal-core-big-tests/actions/runs/31808851949 -- **roughly 2x faster**

TODO:

  - [x] ~~Set `enableErrorFixes` to `false`?~~ Separate issue: #64
  - [x] Remove scaffolding
  - [x] Await integration test