### PR TITLE
Faster reporting of unused definitions

### DIFF
--- a/src/analysis/typepal/ConfigurableScopeGraph.rsc
+++ b/src/analysis/typepal/ConfigurableScopeGraph.rsc
@@ -75,6 +75,11 @@ bool defaultReportUnused (loc _, TModel _) {
     return false;
 }
 
+list[loc] defaultFilterUnused(list[loc] defs, TModel tm) {
+    bool(loc, TModel) reportUnused = tm.config.reportUnused;
+    return [d | loc d <- defs, reportUnused(d, tm)];
+}
+
 // https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#:~:text=A%20URI%20is%20composed%20from,)%2C%20and%20the%20character%20%25%20.
 // gen-delims: : / ? # [ ] @
 // sub-delims: ! $ & ' ( ) * + , ;
@@ -156,6 +161,8 @@ data TypePalConfig(
         void (map[str,Tree] namedTrees, Solver s) postSolver  = void(map[str,Tree] _, Solver _) { return ; },
 
         bool(loc def, TModel tm) reportUnused = defaultReportUnused,
+
+        list[loc](list[loc] defs, TModel tm) filterUnused = defaultFilterUnused,
 
         loc (Define def, str modelName, PathConfig pcfg) createLogicalLoc = defaultLogicalLoc,
 

--- a/src/analysis/typepal/Solver.rsc
+++ b/src/analysis/typepal/Solver.rsc
@@ -141,7 +141,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
 
     AType(AType containerType, Tree selector, loc scope, Solver s) getTypeInNamelessTypeFun = defaultGetTypeInNamelessType;
 
-    bool(loc def, TModel tm) reportUnused = defaultReportUnused;
+    list[loc](list[loc] defs, TModel tm) filterUnused = defaultFilterUnused;
 
     map[loc,loc] logical2physical = tm.logical2physical;
 
@@ -177,7 +177,7 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
         getTypeNamesAndRole = tc.getTypeNamesAndRole;
         getTypeInTypeFromDefineFun = tc.getTypeInTypeFromDefine;
         getTypeInNamelessTypeFun = tc.getTypeInNamelessType;
-        reportUnused = tc.reportUnused;
+        filterUnused = tc.filterUnused;
     }
 
     TypePalConfig solver_getConfig() = tm.config;
@@ -1823,12 +1823,9 @@ Solver newSolver(map[str,Tree] namedTrees, TModel tm){
                       };
         tm.defines = toSet(ldefines);
 
-        for(Define def <- tm.defines){
-            defdefined = solver_toPhysicalLoc(def.defined);
-            if(defdefined notin def2uses && defdefined notin doubleDefs && reportUnused(defdefined, tm)){
-                messages += warning("Unused <prettyRole(def.idRole)> `<def.id>`", defdefined);
-            }
-        }
+        list[loc] unused = filterUnused([l | Define def <- tm.defines, loc l := solver_toPhysicalLoc(def.defined), l notin def2uses, l notin doubleDefs], tm);
+        messages += [warning("Unused <prettyRole(def.idRole)> `<def.id>`", l) | loc l <- unused, Define def := definitions[l]];
+        
         messages =  visit(messages) { case loc l => solver_toPhysicalLoc(l) };
         tm.messages = sortMostPrecise(toList(toSet(messages)));
 


### PR DESCRIPTION
This sub-PR of #54 adds a new Typepal configuration parameter to filter relevant unused definitions from a list ("relevant" means "to-be-reported"). There will be a companion PR for Rascal that takes advantage of this parameter.